### PR TITLE
Feature: Returns null instead of an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ Mongo.Collection.get('books').findOne({ name: 'test' });
 
 ## API
 
-#### Mongo.Collection.get('name', [options])
+#### Mongo.Collection.get('name', [options], faillWithNull)
 
 Returns the collection instance.
 
  - name (String)
  - options (Object) [optional]
    - options.connection (A connection object)
+ - returns null if the collection doesn't exists, false by default
 
 #### Mongo.Collection.getAll()
 

--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -35,6 +35,22 @@ Tinytest.add('nonexistent - throws', function (test) {
   test.throws(getNonexistent, 'not found');
 });
 
+Tinytest.add('nonexistent - doesn\'t throws, returns null', function (test) {
+  function getNonexistent() {
+    return Mongo.Collection.get('truly-non-existent',{}, true);
+  }
+
+  test.equal( getNonexistent() , null);
+});
+
+Tinytest.add('nonexistent - doesn\'t throws, returns null 2', function (test) {
+  function getNonexistent() {
+    return Mongo.Collection.get(null,{}, true);
+  }
+
+  test.equal( getNonexistent() , null);
+});
+
 Tinytest.add('instanceof - matches Mongo.Collection', function (test) {
   var collectionName = 'foo' + test.id;
   var Test = new Mongo.Collection(collectionName);

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -3,7 +3,7 @@ var orig = Mongo.Collection;
 
 Mongo.Collection = function(name, options) {
   orig.call(this, name, options);  // inherit orig
-  
+
   instances.push({
     name: name,
     instance: this,
@@ -16,8 +16,10 @@ Mongo.Collection.prototype.constructor = Mongo.Collection;
 
 _.extend(Mongo.Collection, orig);
 
-Mongo.Collection.get = function(name, options) {
+Mongo.Collection.get = function(name, options, failWithNull) {
   options = options || {};
+  failWithNull = failWithNull || false;
+
   var collection = _.find(instances, function(instance) {
     if (options.connection)
       return instance.name === name &&
@@ -25,9 +27,14 @@ Mongo.Collection.get = function(name, options) {
     return instance.name === name;
   });
 
-  if (! collection)
-    throw new Meteor.Error("Collection not found");
+  if ( !collection ){
+    if( failWithNull ){
+        return null;
+    }
 
+    throw new Meteor.Error("Collection not found");
+  }
+    
   return collection.instance;
 };
 


### PR DESCRIPTION
I've a scenario in which it's better to get null, instead of getting an error. I've a scenario in which I've to create client side collections, I'm getting data from the server using _publishCursor. I'm creating the collection on the client with name "context-" + contextId. This packages is really helpful but I've to wrap everything inside a `try.. catch()`.

To avoid breaking this package for older users than me, I decided that adding a flag, as the last parameters, make possible updating the package without breaking existing code.

Cheers,
Mário Rodrigues