### PR TITLE
Use collection extensions

### DIFF
--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -45,6 +45,11 @@ Tinytest.add('instanceof - Meteor.Collection matches Mongo.Collection', function
   test.instanceOf(Test, Mongo.Collection);
 });
 
+Tinytest.add('instanceof - Meteor.users matches (Mongo/Meteor).Collection', function (test) {
+  test.instanceOf(Meteor.users, Mongo.Collection);
+  test.instanceOf(Meteor.users, Meteor.Collection);
+});
+
 Tinytest.add('use New - keep behavior of Mongo.Collection', function (test) {
   var collectionName = 'foo' + test.id;
   function createWithoutNew() {

--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -39,6 +39,12 @@ Tinytest.add('instanceof - matches Mongo.Collection', function (test) {
   test.instanceOf(Test, Mongo.Collection);
 });
 
+Tinytest.add('instanceof - Meteor.Collection matches Mongo.Collection', function (test) {
+  var collectionName = 'foo' + test.id;
+  var Test = new Meteor.Collection(collectionName);
+  test.instanceOf(Test, Mongo.Collection);
+});
+
 Tinytest.add('use New - keep behavior of Mongo.Collection', function (test) {
   var collectionName = 'foo' + test.id;
   function createWithoutNew() {

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -7,22 +7,6 @@ Meteor.addCollectionExtension(function (name, options) {
     options: options
   });
 });
-var orig = Mongo.Collection;
-
-Mongo.Collection = function(name, options) {
-  orig.call(this, name, options);  // inherit orig
-  
-  instances.push({
-    name: name,
-    instance: this,
-    options: options
-  });
-};
-
-Mongo.Collection.prototype = Object.create(orig.prototype);
-Mongo.Collection.prototype.constructor = Mongo.Collection;
-
-_.extend(Mongo.Collection, orig);
 
 Mongo.Collection.get = function(name, options) {
   options = options || {};

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -1,4 +1,12 @@
 var instances = [];
+
+Meteor.addCollectionExtension(function (name, options) {
+  instances.push({
+    name: name,
+    instance: this,
+    options: options
+  });
+});
 var orig = Mongo.Collection;
 
 Mongo.Collection = function(name, options) {

--- a/package.js
+++ b/package.js
@@ -8,6 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
   api.use(['mongo', 'underscore']);
+  api.use('lai:collection-extensions@0.1.0');
   api.addFiles('mongo-instances.js');
 });
 

--- a/package.js
+++ b/package.js
@@ -14,6 +14,7 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   api.use('tinytest');
+  api.use('accounts-base');
   api.use('dburles:mongo-collection-instances');
   api.addFiles('mongo-instances-tests.js');
 });

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
   api.use(['mongo', 'underscore']);
-  api.use('lai:collection-extensions@0.1.0');
+  api.use('lai:collection-extensions@0.1.1');
   api.addFiles('mongo-instances.js');
 });
 


### PR DESCRIPTION
Okay, so I did it!

In addition, I refactored my fork of [collection hooks](https://github.com/rclai/meteor-collection-hooks/tree/collection-extensions) to use my package and all tests passed! I'll probably pull request them too. If they don't accept that's okay because the package will still work even if collection-hooks doesn't depend on my package.

This should fix [#13](https://github.com/dburles/mongo-collection-instances/issues/13).

If you'd like, you can clone it into a local packages folder to test it and see if it works.

Let me know.