### PR TITLE
No need to manually add Meteor.users instance

### DIFF
--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -57,3 +57,8 @@ Tinytest.add('use New - keep behavior of Mongo.Collection', function (test) {
   }
   test.throws(createWithoutNew, 'use "new" to construct a Mongo.Collection');
 });
+
+Tinytest.add('users - can Mongo.Collection.get Meteor.users instance', function (test) {
+  test.instanceOf(Mongo.Collection.get('users'), Mongo.Collection);
+  test.instanceOf(Mongo.Collection.get('users'), Meteor.Collection);
+});

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -26,11 +26,3 @@ Mongo.Collection.getAll = function() {
 
 // Meteor.Collection will lack ownProperties that are added back to Mongo.Collection
 Meteor.Collection = Mongo.Collection;
-
-if (Meteor.users) {
-  instances.push({
-    name: 'users',
-    instance: Meteor.users,
-    options: undefined
-  });
-}

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
   api.use([
     'mongo',
     'underscore',
-    'lai:collection-extensions@0.1.1']);
+    'lai:collection-extensions@0.1.3']);
   api.addFiles('mongo-instances.js');
 });
 


### PR DESCRIPTION
I saw your last couple of lines, thinking that we might be pushing `Meteor.users` into the array twice, then I found a bug on my `collection-extensions` package that was missing the `users` name argument when applying extensions to `Meteor.users`. Now you don't need to worry about manually adding `Meteor.users` to the `instances` array.