### PR TITLE
Replace deprecated "Meteor.addCollectionExtension" function

### DIFF
--- a/.versions
+++ b/.versions
@@ -9,7 +9,7 @@ ejson@1.0.6
 geojson-utils@1.0.3
 id-map@1.0.3
 json@1.0.3
-lai:collection-extensions@0.1.4
+lai:collection-extensions@0.2.1_1
 local-test:dburles:mongo-collection-instances@0.3.4
 localstorage@1.0.3
 logging@1.0.7

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -1,6 +1,6 @@
 var instances = [];
 
-Meteor.addCollectionExtension(function (name, options) {
+CollectionExtensions.addExtension(function (name, options) {
   instances.push({
     name: name,
     instance: this,

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
   api.use([
     'mongo',
     'underscore',
-    'lai:collection-extensions@0.1.4']);
+    'lai:collection-extensions@0.2.1_1']);
   api.addFiles('mongo-instances.js');
 });
 


### PR DESCRIPTION
`Meteor.addCollectionExtension` is deprecated and should be replaced with `CollectionExtensions.addExtension`.