### PR TITLE
Update collection-extensions dependency

### DIFF
--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -1,6 +1,6 @@
 var instances = [];
 
-Meteor.addCollectionExtension(function (name, options) {
+CollectionExtensions.addExtension(function (name, options) {
   instances.push({
     name: name,
     instance: this,

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
   api.use([
     'mongo',
     'underscore',
-    'lai:collection-extensions@0.1.4']);
+    'lai:collection-extensions@0.2.1_1']);
   api.addFiles('mongo-instances.js');
 });
 
@@ -18,6 +18,7 @@ Package.onTest(function(api) {
   api.use([
     'tinytest',
     'accounts-base',
+    'mongo',
     'dburles:mongo-collection-instances']);
   api.addFiles('mongo-instances-tests.js');
 });


### PR DESCRIPTION
I deprecated the old API and simply created a new namespace. See [this](https://github.com/rclai/meteor-collection-extensions/issues/2).

Also notice that on the tiny tests dependency I had to include `mongo` explicitly to make tests pass in the 1.2 version.