### PR TITLE
Update lai:collection-extensions to v0.3

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'dburles:mongo-collection-instances',
   summary: 'Access your Mongo instances',
-  version: '0.3.5',
+  version: '0.3.6',
   git: 'https://github.com/dburles/mongo-collection-instances.git'
 });
 
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
   api.use([
     'mongo',
     'underscore',
-    'lai:collection-extensions@0.2.1_1']);
+    'lai:collection-extensions@0.3.0']);
   api.addFiles('mongo-instances.js');
 });
 


### PR DESCRIPTION
Updates lai:collection-extensions to the latest version for compatibility with Meteor 2.3+

Speaking of which @dburles are you interested in working on this or would you be interested in moving this to [Meteor Community Packages](https://github.com/Meteor-Community-Packages)?

https://github.com/Meteor-Community-Packages/organization/issues/59